### PR TITLE
Revert _IS_INPUT_DISABLED

### DIFF
--- a/natives.json
+++ b/natives.json
@@ -58839,9 +58839,9 @@
 			"build": "323"
 		},
 		"0xA571D46727E2B718": {
-			"name": "_IS_INPUT_DISABLED",
+			"name": "_GET_LAST_INPUT_METHOD",
 			"jhash": "",
-			"comment": "padIndex: 0 (PLAYER_CONTROL), 1 (unk) and 2 (unk) used in the scripts.\n\nSeems to return true if the input is currently disabled. \"_GET_LAST_INPUT_METHOD\" didn't seem very accurate, but I've left the original description below.\n\n--\n\nindex usually 2\n\nreturns true if the last input method was made with mouse + keyboard, false if it was made with a gamepad",
+			"comment": "The original name and description are accurate. Returns true if last input was made with keyboard/mouse and returns false if it was made with a controller.\n\npadIndex: 0 (PLAYER_CONTROL), 1 (unk) and 2 (unk) used in the scripts.\n\nSeems to return true if the input is currently disabled. \"_GET_LAST_INPUT_METHOD\" didn't seem very accurate, but I've left the original description below.\n\n--\n\nindex usually 2\n\nreturns true if the last input method was made with mouse + keyboard, false if it was made with a gamepad",
 			"params": [
 				{
 					"type": "int",


### PR DESCRIPTION
Reverted _IS_INPUT_DISABLED back to _GET_LAST_INPUT_METHOD as the original description and name more accurately describe the native's function.

An example of this from the freemode script using the current name at the time of writing:
```
if (PAD::_IS_INPUT_DISABLED(0))
{
    func_748("KHANJALI_HELP_1_KM", -1);
}
else
{
    func_748("KHANJALI_HELP_1", -1);
}
```
Help text is replaced with a keyboard/mouse version if the native returns true and a controller version otherwise.

Also, I'm relatively new to the whole github thing, so if this wasn't how I should've gone about this, my apologies.