### PR TITLE
fix incorrect return type of ADD_PETROL_DECAL

### DIFF
--- a/natives.json
+++ b/natives.json
@@ -21792,7 +21792,7 @@
 					"name": "transparency"
 				}
 			],
-			"return_type": "Any",
+			"return_type": "int",
 			"build": "323"
 		},
 		"0x99AC7F0D8B9C893D": {


### PR DESCRIPTION
ADD_PETROL_DECAL returning handle with which we can remove the decal by REMOVE_DECAL.