### PR TITLE
Update UPDATE_ONSCREEN_KEYBOARD status codes

### DIFF
--- a/natives.json
+++ b/natives.json
@@ -37584,7 +37584,7 @@
 		"0x0CF2B696BBF945AE": {
 			"name": "UPDATE_ONSCREEN_KEYBOARD",
 			"jhash": "0x23D0A1CE",
-			"comment": "Returns the current status of the onscreen keyboard, and updates the output.\n\nStatus Codes:\n\n0 - User still editing\n1 - User has finished editing\n2 - User has canceled editing\n3 - Keyboard isn't active",
+			"comment": "Returns the current status of the onscreen keyboard, and updates the output.\n\nStatus Codes:\n\n-1: Keyboard isn't active\n0: User still editing\n1: User has finished editing\n2: User has canceled editing",
 			"params": [],
 			"return_type": "int",
 			"build": "323"


### PR DESCRIPTION
I have only observed -1 when the game is freshly started with no onscreen keyboard active, after an onscreen keyboard was active it will always be 2. I've never observed 3.