### PR TITLE
Fix GET_VEHICLE_MOD_MODIFIER_VALUE return type

### DIFF
--- a/natives.json
+++ b/natives.json
@@ -104403,7 +104403,7 @@
 					"name": "modIndex"
 				}
 			],
-			"return_type": "float",
+			"return_type": "int",
 			"build": "323"
 		},
 		"0x4593CF82AA179706": {


### PR DESCRIPTION
Not a float, since it returns the modifier in carcols:

```xml
        <Item>
          <identifier />
          <modifier value="15" />
          <audioApply value="1.000000" />
          <weight value="20" />
          <type>VMT_ENGINE</type>
        </Item>
```