### PR TITLE
Comment for _GIVE_LOADOUT_TO_PED

### DIFF
--- a/natives.json
+++ b/natives.json
@@ -111913,7 +111913,7 @@
 		"0x68F8BE6AF5CDF8A6": {
 			"name": "_GIVE_LOADOUT_TO_PED",
 			"jhash": "",
-			"comment": "GIVE_*",
+			"comment": "Gives the specified loadout to the specified ped. \nLoadouts are defined in common.rpf\\data\\ai\\loadouts.meta",
 			"params": [
 				{
 					"type": "Ped",


### PR DESCRIPTION
Adds a comment mentioning where are loadouts defined.