### PR TITLE
Research 0xE67C6DFD386EA5E7

### DIFF
--- a/natives.json
+++ b/natives.json
@@ -2457,7 +2457,7 @@
 		"0xB165AB7C248B2DC1": {
 			"name": "UNLOCK_MISSION_NEWS_STORY",
 			"jhash": "0xCCD9ABE4",
-			"comment": "I see this as a native that would of been used back in GTA III when you finally unlocked the bridge to the next island and such.",
+			"comment": "\"news\" that play on the radio afrer you've done something in story mode(?)",
 			"params": [
 				{
 					"type": "int",

--- a/natives.json
+++ b/natives.json
@@ -2457,7 +2457,7 @@
 		"0xB165AB7C248B2DC1": {
 			"name": "UNLOCK_MISSION_NEWS_STORY",
 			"jhash": "0xCCD9ABE4",
-			"comment": "\"news\" that play on the radio afrer you've done something in story mode(?)",
+			"comment": "\"news\" that play on the radio after you've done something in story mode(?)",
 			"params": [
 				{
 					"type": "int",

--- a/natives.json
+++ b/natives.json
@@ -51335,7 +51335,7 @@
 		"0x7718D2E2060837D2": {
 			"name": "NETWORK_PLAYER_GET_NAME",
 			"jhash": "0xCE48F260",
-			"comment": "Returns the name of a given player. Returns \"**Invalid**\" if CPlayerInfo of the given player cannot be retrieved or the player doesn't exist.",
+			"comment": "Returns the name of a given player. Returns \"**Invalid**\" if rlGamerInfo of the given player cannot be retrieved or the player doesn't exist.",
 			"params": [
 				{
 					"type": "Player",
@@ -51348,7 +51348,7 @@
 		"0x4927FC39CD0869A0": {
 			"name": "NETWORK_PLAYER_GET_USERID",
 			"jhash": "0x4EC0D983",
-			"comment": "Takes a 24 char buffer. Returns the buffer or \"**Invalid**\" if CPlayerInfo of the given player cannot be retrieved or the player doesn't exist.",
+			"comment": "Returns a string of the player's Rockstar Id. \nTakes a 24 char buffer. Returns the buffer or \"**Invalid**\" if rlGamerInfo of the given player cannot be retrieved or the player doesn't exist.",
 			"params": [
 				{
 					"type": "Player",
@@ -51368,7 +51368,7 @@
 		"0x544ABDDA3B409B6D": {
 			"name": "NETWORK_PLAYER_IS_ROCKSTAR_DEV",
 			"jhash": "0xF6659045",
-			"comment": "Checks if a specific value (BYTE) in CPlayerInfo is nonzero.\nReturns always false in Singleplayer.\n\nNo longer used for dev checks since first mods were released on PS3 & 360.\nR* now checks with the is_dlc_present native for the dlc hash 2532323046,\nif that is present it will unlock dev stuff.",
+			"comment": "Checks if a specific value (BYTE) in CNetGamePlayer is nonzero.\nReturns always false in Singleplayer.\n\nNo longer used for dev checks since first mods were released on PS3 & 360.\nR* now checks with the IS_DLC_PRESENT native for the dlc hash 2532323046,\nif that is present it will unlock dev stuff.",
 			"params": [
 				{
 					"type": "Player",

--- a/natives.json
+++ b/natives.json
@@ -29802,13 +29802,13 @@
 			"build": "323"
 		},
 		"0xE67C6DFD386EA5E7": {
-			"name": "_0xE67C6DFD386EA5E7",
+			"name": "_ALLOW_ADDITIONAL_INFO_FOR_MULTIPLAYER_HUD_CASH",
 			"jhash": "0x5476B9FD",
-			"comment": "",
+			"comment": "Controls whether to display 'Cash'/'Bank' next to the money balance HUD in Multiplayer (https://i.imgur.com/MiYUtNl.png) \nReal name is somewhere between ADD_TO* and ALLOW_MISSION* alphabetically.",
 			"params": [
 				{
 					"type": "BOOL",
-					"name": "p0"
+					"name": "allow"
 				}
 			],
 			"return_type": "void",


### PR DESCRIPTION
I have researched the functionality that displays a text saying cash/bank before your balance, when you start playing GTA Online for the first time, in order to figure out which one is which.
For context, this is what I mean; https://i.imgur.com/MiYUtNl.png

This native is extremely simple, it just sets certain bool. The code that handles the money balance HUD in the check for whether to use the functionality mentioned above