### PR TITLE
Fix duplicate "entity" parameters in WAYPOINT_PLAYBACK_START_SHOOTING_AT_PED

### DIFF
--- a/natives.json
+++ b/natives.json
@@ -99976,11 +99976,11 @@
 			"params": [
 				{
 					"type": "Entity",
-					"name": "entity1"
+					"name": "entity"
 				},
 				{
-					"type": "Entity",
-					"name": "entity2"
+					"type": "Ped",
+					"name": "target"
 				},
 				{
 					"type": "BOOL",

--- a/natives.json
+++ b/natives.json
@@ -99976,11 +99976,11 @@
 			"params": [
 				{
 					"type": "Entity",
-					"name": "entity"
+					"name": "entity1"
 				},
 				{
 					"type": "Entity",
-					"name": "entity"
+					"name": "entity2"
 				},
 				{
 					"type": "BOOL",


### PR DESCRIPTION
The commit simply renames two `entity` parameters in WAYPOINT_PLAYBACK_START_SHOOTING_AT_PED to `entity1` and `entity2`.