### PR TITLE
Fixed description and param name of setPedHeadOverlayTint

### DIFF
--- a/natives.json
+++ b/natives.json
@@ -73090,7 +73090,7 @@
 		"0x497BF74A7B9CB952": {
 			"name": "SET_PED_HEAD_OVERLAY_TINT",
 			"jhash": "",
-			"comment": "\n\nColorType is 1 for eyebrows, beards, and chest hair; 2 for blush and lipstick; and 0 otherwise, though not called in those cases.\n\nCalled after SET_PED_HEAD_OVERLAY().",
+			"comment": "colorCount is 2 for Makeup.\ncolorCount is 1 for Facial Hair, Eyebrows, Blush, Lipstick and Chest Hair.\ncolorCount is 0 for everything else, though not called in those cases.\n\nCalled after SET_PED_HEAD_OVERLAY().",
 			"params": [
 				{
 					"type": "Ped",
@@ -73102,7 +73102,7 @@
 				},
 				{
 					"type": "int",
-					"name": "colorType"
+					"name": "colorCount"
 				},
 				{
 					"type": "int",


### PR DESCRIPTION
The current description and colorType parameter name is wrong and misleading.

ColorType is a misleading parameter name because it doesn't describe a type, only the amount of colors.
Lipstick and Blush have ColorType = 1 but are using Makeup tints.
Every other overlay with ColorType = 1 uses hair tints.
If it would describe a ColorType, this wouldn't be true.

Also the mentioned overlays with their ColorTypes are wrong. I've tested all ingame and this is the result:
| Overlay ID | Guessed Overlay Name | ColorCount |
| ----------- | ---------------- | ------------ |
| 0 | Facial Blemish | 0 |
| 1 | Facial Hair | 1 |
| 2 | Eyebrows | 1 |
| 3 | Age | 0 |
| 4 | Makeup | 2 |
| 5 | Blush | 1 |
| 6 | Complexion | 0 |
| 7 | Sun Damage | 0 |
| 8 | Lipstick | 1 |
| 9 | Freckles | 0 |
| 10 | Chest Hair | 1 |
| 11 | Body Blemish | 0 |
| 12 | Add Body Blemishes | 0 |

I've renamed the parameter and updated the description of setPedHeadOverlayTint so others aren't mislead anymore aswell.