### PR TITLE
Added whole outComponent struct of getTattooShopDlcItemData

### DIFF
--- a/natives.json
+++ b/natives.json
@@ -15865,7 +15865,7 @@
 		"0xFF56381874F82086": {
 			"name": "GET_TATTOO_SHOP_DLC_ITEM_DATA",
 			"jhash": "0x2E9D628C",
-			"comment": "Character types:\n0 = Michael, \n1 = Franklin, \n2 = Trevor, \n3 = MPMale, \n4 = MPFemale\n\n\nenum TattooZoneData\n{  \n    ZONE_TORSO = 0,  \n    ZONE_HEAD = 1,  \n    ZONE_LEFT_ARM = 2,  \n    ZONE_RIGHT_ARM = 3,  \n    ZONE_LEFT_LEG = 4,  \n    ZONE_RIGHT_LEG = 5,  \n    ZONE_UNKNOWN = 6,\n    ZONE_NONE = 7,  \n};\nstruct outComponent\n{\n    // these vars are suffixed with 4 bytes of padding each.\n    uint unk;\n    int unk2;\n    uint tattooCollectionHash;\n    uint tattooNameHash;\n    int unk3;\n    TattooZoneData zoneId;\n    uint unk4;\n    uint unk5;\n    // maybe more, not sure exactly, decompiled scripts are very vague around this part.\n}",
+			"comment": "Character types:\n0 = Michael, \n1 = Franklin, \n2 = Trevor, \n3 = MPMale, \n4 = MPFemale\n\n\nenum TattooZoneData\n{  \n    ZONE_TORSO = 0,  \n    ZONE_HEAD = 1,  \n    ZONE_LEFT_ARM = 2,  \n    ZONE_RIGHT_ARM = 3,  \n    ZONE_LEFT_LEG = 4,  \n    ZONE_RIGHT_LEG = 5,  \n    ZONE_UNKNOWN = 6,\n    ZONE_NONE = 7,  \n};\n//size 120\nstruct outComponent\n{\nuint lockHash,\nuint id,\nuint collection,\nuint preset,\nuint cost,\nuint eFacing,\nuint updateGroup,\nstring textLabel // length 64\n}\n}",
 			"params": [
 				{
 					"type": "int",


### PR DESCRIPTION
The outComponent seems to have the following structure:
//size 120
struct outComponent
{
uint lockHash,
uint id,
uint collection,
uint preset,
uint cost,
uint eFacing,
uint updateGroup,
string textLabel // length 64
}

Old description mentioned the enum TattooZoneData. Maybe that is eFacing? Not sure. This one is working and useable compared to the old one though.
Researched by TomGrobbe: https://rage.mp/files/file/294-mpgamedata/