### PR TITLE
b2802

### DIFF
--- a/natives.json
+++ b/natives.json
@@ -103569,9 +103569,9 @@
 			"build": "944"
 		},
 		"0x85FC953F6C6CBDE1": {
-			"name": "_0x85FC953F6C6CBDE1",
+			"name": "_SET_BOUNDS_AFFECT_WATER_PROBES",
 			"jhash": "",
-			"comment": "",
+			"comment": "Use the vehicle bounds (instead of viewport) when deciding if a vehicle is sufficiently above the water (waterheight.dat), bypassing wave simulation checks",
 			"params": [
 				{
 					"type": "Vehicle",
@@ -103579,7 +103579,7 @@
 				},
 				{
 					"type": "BOOL",
-					"name": "p1"
+					"name": "toggle"
 				}
 			],
 			"return_type": "void",


### PR DESCRIPTION
The only native from b2802 without a name. 

Essentially it improves the precision of a vehicles `waterheight.dat` check (i.e., is the bottom of the vehicle high enough to avoid having to check the wave simulation). Or something along those lines.

The game scripts make reference to some `_VEH_GWVP` labels and the logic around its use includes a new hardcode for `dodo`'s at `1312.7688, 4218.2744, 32.0`. It is unclear what this is trying to solve (some LOD/interior/teleport issue?)