### PR TITLE
add a better comment to "GET_FILENAME_FOR_AUDIO_CONVERSATION"

### DIFF
--- a/natives.json
+++ b/natives.json
@@ -27725,7 +27725,7 @@
 		"0x7B5280EBA9840C72": {
 			"name": "GET_FILENAME_FOR_AUDIO_CONVERSATION",
 			"jhash": "0x95C4B5AD",
-			"comment": "Gets a string literal from a label name.",
+			"comment": "Gets a localized string literal from a label name. Can be used for output of e.g. VEHICLE::GET_LIVERY_NAME. To check if a GXT label can be localized with this, HUD::DOES_TEXT_LABEL_EXIST can be used.",
 			"params": [
 				{
 					"type": "const char*",


### PR DESCRIPTION
As described in my previous pull request (https://github.com/alloc8or/gta5-nativedb-data/pull/233) the native: GET_FILENAME_FOR_AUDIO_CONVERSATION is extremely misleading in its GTA name.
It is used to get a localized name for a GXT label.

I have therefore added some more information about this in the comment to the native