### PR TITLE
Add default arguments

### DIFF
--- a/natives.json
+++ b/natives.json
@@ -12150,7 +12150,8 @@
 				},
 				{
 					"type": "BOOL",
-					"name": "alive"
+					"name": "alive",
+					"default": "FALSE"
 				}
 			],
 			"return_type": "Vector3",

--- a/natives.json
+++ b/natives.json
@@ -14560,7 +14560,8 @@
 				},
 				{
 					"type": "int",
-					"name": "p2"
+					"name": "p2",
+					"default": "0"
 				}
 			],
 			"return_type": "void",
@@ -69373,7 +69374,8 @@
 				},
 				{
 					"type": "BOOL",
-					"name": "includeEntering"
+					"name": "includeEntering",
+					"default": "FALSE"
 				}
 			],
 			"return_type": "Vehicle",
@@ -85467,7 +85469,8 @@
 				},
 				{
 					"type": "int",
-					"name": "p8"
+					"name": "p8",
+					"default": "0"
 				}
 			],
 			"return_type": "int",

--- a/schema.json
+++ b/schema.json
@@ -22,6 +22,10 @@
 									"name": {
 										"type": "string",
 										"pattern": "^[A-Za-z_]+[A-Za-z0-9_]*$"
+									},
+									"default": {
+										"type": "string",
+										"pattern": "^(0|TRUE|FALSE)$"
 									}
 								},
 								"required": ["type", "name"],


### PR DESCRIPTION
I know that only ~~3~~ 4 natives having this new attribute isn't gonna the most impressive start, but I'm hoping that in the long run, this will help simplify usage of natives:
- Make it easier to call certain natives, e.g. `SET_ENTITY_HEALTH`'s `p2` will pretty much always be `0`, no need to specify it explicitly.
- Make it easier to upgrade to newer natives versions, e.g. if there's a new `p2` or `p3` it can just be defaulted to `0`, so it has exactly the same value as it did before.

Interoperability considerations:
- The "default" field matches https://github.com/DottieDot/GTAV-NativeDB/blob/master/special-schema.json except I've also restricted the possible values to make it easier for users of the nativedb to filter this value.