### PR TITLE
Fix param 4 and 5 for GET_NTH_CLOSEST_VEHICLE_NODE_ID_WITH_HEADING

### DIFF
--- a/natives.json
+++ b/natives.json
@@ -68597,11 +68597,11 @@
 				},
 				{
 					"type": "float",
-					"name": "p7"
+					"name": "zMeasureMult"
 				},
 				{
 					"type": "float",
-					"name": "p8"
+					"name": "zTolerance"
 				}
 			],
 			"return_type": "int",

--- a/natives.json
+++ b/natives.json
@@ -72839,24 +72839,24 @@
 					"name": "ped"
 				},
 				{
-					"type": "Any",
-					"name": "p1"
+					"type": "float",
+					"name": "x"
 				},
 				{
 					"type": "float",
-					"name": "p2"
+					"name": "y"
+				},
+				{
+					"type": "float",
+					"name": "z"
+				},
+				{
+					"type": "float",
+					"name": "radius"
 				},
 				{
 					"type": "Hash",
 					"name": "hash"
-				},
-				{
-					"type": "Any",
-					"name": "p4"
-				},
-				{
-					"type": "Any",
-					"name": "p5"
 				}
 			],
 			"return_type": "void",

--- a/natives.json
+++ b/natives.json
@@ -68584,12 +68584,12 @@
 					"name": "nthClosest"
 				},
 				{
-					"type": "Vector3*",
-					"name": "outPosition"
-				},
-				{
 					"type": "float*",
 					"name": "outHeading"
+				},
+				{
+					"type": "int*",
+					"name": "outNumLanes"
 				},
 				{
 					"type": "int",

--- a/natives.json
+++ b/natives.json
@@ -82199,16 +82199,16 @@
 					"name": "player"
 				},
 				{
-					"type": "Vector3*",
-					"name": "position"
+					"type": "float",
+					"name": "x"
 				},
 				{
-					"type": "BOOL",
-					"name": "p2"
+					"type": "float",
+					"name": "y"
 				},
 				{
-					"type": "BOOL",
-					"name": "p3"
+					"type": "float",
+					"name": "z"
 				}
 			],
 			"return_type": "void",

--- a/natives.json
+++ b/natives.json
@@ -82199,16 +82199,24 @@
 					"name": "player"
 				},
 				{
-					"type": "Vector3*",
-					"name": "position"
+					"type": "float",
+					"name": "x"
+				},
+				{
+					"type": "float",
+					"name": "y"
+				},
+				{
+					"type": "float",
+					"name": "z"
 				},
 				{
 					"type": "BOOL",
-					"name": "p2"
+					"name": "p4"
 				},
 				{
 					"type": "BOOL",
-					"name": "p3"
+					"name": "p5"
 				}
 			],
 			"return_type": "void",

--- a/natives_gen9.json
+++ b/natives_gen9.json
@@ -73272,24 +73272,24 @@
 					"name": "ped"
 				},
 				{
-					"type": "Any",
-					"name": "p1"
+					"type": "float",
+					"name": "x"
 				},
 				{
 					"type": "float",
-					"name": "p2"
+					"name": "y"
+				},
+				{
+					"type": "float",
+					"name": "z"
+				},
+				{
+					"type": "float",
+					"name": "radius"
 				},
 				{
 					"type": "Hash",
 					"name": "hash"
-				},
-				{
-					"type": "Any",
-					"name": "p4"
-				},
-				{
-					"type": "Any",
-					"name": "p5"
 				}
 			],
 			"return_type": "void",

--- a/natives_gen9.json
+++ b/natives_gen9.json
@@ -69030,11 +69030,11 @@
 				},
 				{
 					"type": "float",
-					"name": "p7"
+					"name": "zMeasureMult"
 				},
 				{
 					"type": "float",
-					"name": "p8"
+					"name": "zTolerance"
 				}
 			],
 			"return_type": "int",

--- a/natives_gen9.json
+++ b/natives_gen9.json
@@ -82632,16 +82632,24 @@
 					"name": "player"
 				},
 				{
-					"type": "Vector3*",
-					"name": "position"
+					"type": "float",
+					"name": "x"
+				},
+				{
+					"type": "float",
+					"name": "y"
+				},
+				{
+					"type": "float",
+					"name": "z"
 				},
 				{
 					"type": "BOOL",
-					"name": "p2"
+					"name": "p4"
 				},
 				{
 					"type": "BOOL",
-					"name": "p3"
+					"name": "p5"
 				}
 			],
 			"return_type": "void",

--- a/natives_gen9.json
+++ b/natives_gen9.json
@@ -82632,16 +82632,16 @@
 					"name": "player"
 				},
 				{
-					"type": "Vector3*",
-					"name": "position"
+					"type": "float",
+					"name": "x"
 				},
 				{
-					"type": "BOOL",
-					"name": "p2"
+					"type": "float",
+					"name": "y"
 				},
 				{
-					"type": "BOOL",
-					"name": "p3"
+					"type": "float",
+					"name": "z"
 				}
 			],
 			"return_type": "void",

--- a/natives_gen9.json
+++ b/natives_gen9.json
@@ -69017,12 +69017,12 @@
 					"name": "nthClosest"
 				},
 				{
-					"type": "Vector3*",
-					"name": "outPosition"
-				},
-				{
 					"type": "float*",
 					"name": "outHeading"
+				},
+				{
+					"type": "int*",
+					"name": "outNumLanes"
 				},
 				{
 					"type": "int",


### PR DESCRIPTION
See Freemode where the 5th argument being used, var4, couldn't be a Vector3, but must be float, and Var5 declared directly below it is being used as an int. These variables shouldn't overlap. Freemode @v3788:
```cpp
int func_1119(Vector3* vParam0, Vector3* vParam1, var* uParam2)//Position - 0x8376F
{
[...]
	Vector3 vVar4; // <-- Impossible, can't be a struct size  of 3 with iVar5 following it immediately
	int iVar5;
[...]
	iVar5 = 0;
[...]
		iVar5 += 2;
		iVar5++;
[...]
	iVar5 += 4;
[...]
		iVar8 = PATHFIND::GET_NTH_CLOSEST_VEHICLE_NODE_ID_WITH_HEADING(*vParam0, (iVar0 * iVar17), &vVar4, &fVar9, iVar5, fVar13, fVar14);
```

If you reverse the native, it is clear that this parameter is filled with the heading in 0.0 to 360.0 degrees as a float pointer, not as a Vector3 pointer. (If it were, a wrapper would also be present to convert from 3 consecutive floats to 3 script floats with 8-byte alignment and there is none.) Furthermore the 6th argument is used internally as an int pointer, for numLanes. It seems the only difference between this function and `GET_NTH_CLOSEST_VEHICLE_NODE_WITH_HEADING` is that the `Vector3* outHeading` is omitted, instead of the numLanes parameter.

This also explains why in Freemode func_1119 v3788 `PATHFIND::GET_VEHICLE_NODE_POSITION` is called immediately after calling `PATHFIND::GET_NTH_CLOSEST_VEHICLE_NODE_ID_WITH_HEADING`, this wouldn't make sense otherwise.
